### PR TITLE
Small style tweak

### DIFF
--- a/includes/css/main.css
+++ b/includes/css/main.css
@@ -180,7 +180,7 @@ hr {
 
 #content-container a:hover {text-decoration: underline;}
 
-#content-container ul {margin-left: 20px;}
+#content-container ul {margin-left: 30px;}
 
 #content-container li {
 	font-weight: 300;
@@ -232,7 +232,7 @@ hr {
 }
 
 #content-container .illustration ul {
-	font-size: 80%;
+	font-size: 70%;
 	text-align: left;
 }
 	


### PR DESCRIPTION
I've tweaked the list styles for (IMO) better alignment of unordered lists. I've centred the padding around the list bullets for a more consistent look, and dropped the font size to smaller than the headers.
## Full Width

Existing:
![existing](http://f.cl.ly/items/3L0z280N0R2F3o0Q1t3f/Screen%20Shot%202013-09-03%20at%207.28.25%20PM.png)
New:
![new](http://f.cl.ly/items/3Y3f1P2x3S3s0a3N3M1N/Screen%20Shot%202013-09-03%20at%207.28.09%20PM.png)
## Mobile Width

Existing:
![existing](http://f.cl.ly/items/21072R2Y2M0F1c1C3l1N/Screen%20Shot%202013-09-03%20at%207.30.38%20PM.png)
New:
![new](http://f.cl.ly/items/0x2o1A3M002h310K2c3M/Screen%20Shot%202013-09-03%20at%207.30.23%20PM.png)
